### PR TITLE
添加了json.dependencies不存在时的容错逻辑

### DIFF
--- a/src/tmod.js
+++ b/src/tmod.js
@@ -226,6 +226,14 @@ Tmod.prototype = {
             };
 
         }
+        
+        //有些项目的package.json里只有devDependencies而没有dependencies
+        //那么下面的replace那行代码就会出现can't read property 'tmodjs' of undefined的错误
+        //这里添加容错逻辑
+        
+        if (!json.dependencies) {
+            json.dependencies = json.devDependencies;
+        }
 
 
         var targetVersion = json.dependencies.tmodjs.replace(/^~/, '');


### PR DESCRIPTION
有些项目的package.json里只有devDependencies而没有dependencies，那么在getConfig方法里，var targetVersion那行代码就会出现can't read property 'tmodjs' of undefined的错误
